### PR TITLE
[TreeIndex] TreeIndex from_u32 constructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smtree"
-version = "0.1.0"
+version = "0.1.1"
 repository = "https://github.com/novifinancial/smtree"
-keywords = ["cryptography", "accumulator", "Merkle-tree", "privacy", "sampling", "auditing", "padding", "sparse-tree"]
+keywords = ["cryptography", "accumulator", "Merkle-tree", "sparse-tree", "sampling"]
 description = "SMTree is a flexible sparse tree accumulator that can support various tree types via traits for custom node-merging (i.e., Merkle tree hashes) and tree-padding logic. The api supports single and batch inclusion proofs and random sampling."
 authors = ["Konstantinos Chalkias <kostascrypto@fb.com>", "Yan Ji <yji@fb.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -37,13 +37,10 @@ Now you are all prepared to build your sparse Merkle tree!
 Contributors
 ------------
 
-The authors of this code are Konstantinos Chalkias
-([@kchalkias](https://github.com/kchalkias)) and Yan Ji ([@iseriohn](https://github.com/iseriohn)).
+The original authors of this code are Konstantinos Chalkias
+([@kchalkias](https://github.com/kchalkias)) and Yan Ji ([@iseriohn](https://github.com/iseriohn)), with contributions 
+from Kevin Lewi ([@kevinlewi](https://github.com/kevinlewi)) and Irakliy Khaburzaniya ([@irakliyk](https://github.com/irakliyk)).
 To learn more about contributing to this project, [see this document](./CONTRIBUTING.md).
-
-#### Acknowledgments
-
-Special thanks go to Kevin Lewi for improving this implementation.
 
 License
 -------

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ use crate::index::MAX_HEIGHT;
 pub enum DecodingError {
     /// Decoded tree height or index height exceeds [MAX_HEIGHT]
     ExceedMaxHeight,
+    /// Provided index does not fit to the tree
+    IndexOverflow,
     /// There are more bytes than required for deserialization.
     TooManyEncodedBytes,
     /// Bytes are not enough for deserialization.
@@ -32,6 +34,9 @@ impl core::fmt::Display for DecodingError {
                     "The height exceeds the maximum height, {}, in an SMT.",
                     MAX_HEIGHT
                 )?;
+            }
+            DecodingError::IndexOverflow => {
+                write!(f, "Index Overflow")?;
             }
             DecodingError::TooManyEncodedBytes => {
                 write!(f, "Too many encoded bytes than required")?;

--- a/src/index.rs
+++ b/src/index.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 use crate::{
     error::DecodingError,
     tree::ChildDir,
-    utils::{bytes_to_usize, usize_to_bytes},
+    utils::{bytes_to_usize, tree_index_from_u32, usize_to_bytes},
 };
 
 // We store the position of each tree node in a byte array of size 32,
@@ -93,6 +93,18 @@ impl TreeIndex {
             panic!("{}", DecodingError::ExceedMaxHeight);
         }
         TreeIndex { height, path: pos }
+    }
+
+    /// Construct TreeIndex from a u32 leaf position.
+    pub fn from_u32(height: usize, pos: u32) -> TreeIndex {
+        if height > MAX_HEIGHT {
+            panic!("{}", DecodingError::ExceedMaxHeight);
+        }
+        // Check if index fits to the tree.
+        if 32 - pos.leading_zeros() > height as u32 {
+            panic!("{}", DecodingError::IndexOverflow);
+        }
+        tree_index_from_u32(height, pos)
     }
 
     /// Returns a tree index of the left-most node (all bits in the path being 0) at the given height.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -126,7 +126,8 @@ pub fn generate_sorted_index_value_pairs<V: Default + Clone + Rand>(
     list
 }
 
-pub fn set_pos_best(height: usize, _idx: u32) -> TreeIndex {
+/// Convert a u32 to TreeIndex
+pub fn tree_index_from_u32(height: usize, _idx: u32) -> TreeIndex {
     let mut new_pos = [0u8; BYTE_NUM];
     let mut idx = _idx;
     for i in (0..height).rev() {
@@ -134,6 +135,14 @@ pub fn set_pos_best(height: usize, _idx: u32) -> TreeIndex {
         idx >>= 1;
     }
     TreeIndex::new(height, new_pos)
+}
+
+#[deprecated(
+    since = "0.1.1",
+    note = "Please use the tree_index_from_u32 function instead"
+)]
+pub fn set_pos_best(height: usize, _idx: u32) -> TreeIndex {
+    tree_index_from_u32(height, _idx)
 }
 
 pub fn set_pos_worst(height: usize, _idx: u32, depth: usize) -> TreeIndex {
@@ -212,7 +221,7 @@ pub fn print_output<P: Clone + Default + Mergeable + Paddable + ProofExtractable
             &internals,
         );
         for j in 1..1 << i {
-            let pos = set_pos_best(i, j as u32);
+            let pos = tree_index_from_u32(i, j as u32);
             print_node(
                 1 << tree.get_height() >> (i - 1),
                 &pos,


### PR DESCRIPTION
Addressing Issue https://github.com/novifinancial/smtree/issues/9 re `TreeIndex::from_u32` constructor. For compatibility reasons we didn't remove functions or make them private. To provide a `from_u64` in upcoming PRs.  