### PR TITLE
TreeIndex from_u64 constructor

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 use crate::{
     error::DecodingError,
     tree::ChildDir,
-    utils::{bytes_to_usize, tree_index_from_u32, usize_to_bytes},
+    utils::{bytes_to_usize, tree_index_from_u64, usize_to_bytes},
 };
 
 // We store the position of each tree node in a byte array of size 32,
@@ -96,6 +96,10 @@ impl TreeIndex {
     }
 
     /// Construct TreeIndex from a u32 leaf position.
+    ///
+    /// Panics if:
+    /// * `height` exceeds [MAX_HEIGHT](../index/constant.MAX_HEIGHT.html).
+    /// * `pos` is not a valid leaf position in the tree of the specified `height`.
     pub fn from_u32(height: usize, pos: u32) -> TreeIndex {
         if height > MAX_HEIGHT {
             panic!("{}", DecodingError::ExceedMaxHeight);
@@ -104,7 +108,23 @@ impl TreeIndex {
         if 32 - pos.leading_zeros() > height as u32 {
             panic!("{}", DecodingError::IndexOverflow);
         }
-        tree_index_from_u32(height, pos)
+        tree_index_from_u64(height, pos as u64)
+    }
+
+    /// Construct TreeIndex from a u64 leaf position.
+    ///
+    /// Panics if:
+    /// * `height` exceeds [MAX_HEIGHT](../index/constant.MAX_HEIGHT.html).
+    /// * `pos` is not a valid leaf position in the tree of the specified `height`.
+    pub fn from_u64(height: usize, pos: u64) -> TreeIndex {
+        if height > MAX_HEIGHT {
+            panic!("{}", DecodingError::ExceedMaxHeight);
+        }
+        // Check if index fits to the tree.
+        if 64 - pos.leading_zeros() > height as u32 {
+            panic!("{}", DecodingError::IndexOverflow);
+        }
+        tree_index_from_u64(height, pos)
     }
 
     /// Returns a tree index of the left-most node (all bits in the path being 0) at the given height.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -126,10 +126,10 @@ pub fn generate_sorted_index_value_pairs<V: Default + Clone + Rand>(
     list
 }
 
-/// Convert a u32 to TreeIndex
-pub fn tree_index_from_u32(height: usize, _idx: u32) -> TreeIndex {
+/// Convert a u64 to TreeIndex
+pub fn tree_index_from_u64(height: usize, idx: u64) -> TreeIndex {
     let mut new_pos = [0u8; BYTE_NUM];
-    let mut idx = _idx;
+    let mut idx = idx;
     for i in (0..height).rev() {
         new_pos[i / BYTE_SIZE] += ((idx & 1) << (i % BYTE_SIZE)) as u8;
         idx >>= 1;
@@ -141,8 +141,8 @@ pub fn tree_index_from_u32(height: usize, _idx: u32) -> TreeIndex {
     since = "0.1.1",
     note = "Please use the tree_index_from_u32 function instead"
 )]
-pub fn set_pos_best(height: usize, _idx: u32) -> TreeIndex {
-    tree_index_from_u32(height, _idx)
+pub fn set_pos_best(height: usize, idx: u32) -> TreeIndex {
+    tree_index_from_u64(height, idx as u64)
 }
 
 pub fn set_pos_worst(height: usize, _idx: u32, depth: usize) -> TreeIndex {
@@ -221,7 +221,7 @@ pub fn print_output<P: Clone + Default + Mergeable + Paddable + ProofExtractable
             &internals,
         );
         for j in 1..1 << i {
-            let pos = tree_index_from_u32(i, j as u32);
+            let pos = tree_index_from_u64(i, j as u64);
             print_node(
                 1 << tree.get_height() >> (i - 1),
                 &pos,


### PR DESCRIPTION
This PR adds a new constructor to `TreeIndex` to create indexes from `u64` leaf positions.